### PR TITLE
Add new() for VOICE struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,29 @@ pub struct espeak_VOICE {
 	spare: *mut c_void
 }
 
+impl espeak_VOICE {
+    	pub fn new(
+		name: *const c_char,
+		languages: *const c_char,
+		identifier: *const c_char,
+		gender: c_uchar,
+		age: c_uchar,
+		variant: c_uchar) -> espeak_VOICE
+	{
+		espeak_VOICE {
+			name,
+			languages,
+			identifier,
+			gender,
+			age,
+			variant,
+			xx1: 0,
+			score: 0,
+			spare: std::ptr::null_mut(),
+		}
+	}
+}
+
 pub type t_espeak_callback = extern "C" fn(*mut c_short, c_int, *mut espeak_EVENT) -> c_int;
 
 #[link(name = "espeak")]


### PR DESCRIPTION
Currently, we're unable to create espeak_VOICE data structure, because x11, score, and spare fields are private. I introduce new() so a user can create an object of this type.